### PR TITLE
Fix 2 of the 3 Warnings in latest issue 

### DIFF
--- a/src/pages/Store.jsx
+++ b/src/pages/Store.jsx
@@ -14,7 +14,7 @@ function Store() {
     <StoreStyledContainer>
       <div className="store-container">
         <div className='top-image-container'>
-          <img src='./images/aiony-haust-cutout.png'></img>
+          <img src='./images/aiony-haust-cutout.png' alt='unavailable'></img>
         </div>
         <div className='spot-light-container'>
           <div className='spot-light'>

--- a/src/styles/Global.styled.js
+++ b/src/styles/Global.styled.js
@@ -1,4 +1,4 @@
-import styled, { createGlobalStyle, keyframes } from 'styled-components';
+import styled, { createGlobalStyle, } from 'styled-components';
 
 export const GlobalFont = createGlobalStyle`
   @font-face {


### PR DESCRIPTION
### add alt tag to .png to fix terminal error

- Added a alt tag in a .png image in Store.jsx to fix terminal waring.
- Commit has: `3ec4b7f`

### removed keyframes from line 1 because it was never used and created warning

- keyframes was not used in Global.styled.js which resulted in a terminal warning.
- Commit hash: `3c9554a`